### PR TITLE
feat: Added support for type 'string'

### DIFF
--- a/projects/ng-apexcharts/src/lib/model/apex-types.ts
+++ b/projects/ng-apexcharts/src/lib/model/apex-types.ts
@@ -97,13 +97,13 @@ export interface ApexChart {
   toolbar?: {
     show?: boolean;
     tools?: {
-      download?: boolean;
-      selection?: boolean;
-      zoom?: boolean;
-      zoomin?: boolean;
-      zoomout?: boolean;
-      pan?: boolean;
-      reset?: boolean;
+      download?: boolean | string;
+      selection?: boolean | string;
+      zoom?: boolean | string;
+      zoomin?: boolean | string;
+      zoomout?: boolean | string;
+      pan?: boolean | string;
+      reset?: boolean | string;
     };
     autoSelected?: "zoom" | "selection" | "pan";
   };


### PR DESCRIPTION
Added support for type 'string' in download option of toolbar.
Most versions of apexcharts support 'boolean' and 'string' for download option of toolbar.
So adding this type support makes it more extensible.